### PR TITLE
Remove dependency on `url` for runtime reporting.

### DIFF
--- a/.changeset/curly-rocks-notice.md
+++ b/.changeset/curly-rocks-notice.md
@@ -1,0 +1,5 @@
+---
+"@lukesheard/esbuild-scripts": patch
+---
+
+Fix issue where url is not resolved when using a built version of the packages.

--- a/packages/esbuild-scripts/src/plugins/incremental-compile.ts
+++ b/packages/esbuild-scripts/src/plugins/incremental-compile.ts
@@ -6,7 +6,6 @@ import * as fs from "fs/promises";
 import * as paths from "../config/paths";
 import * as logger from "../utils/logger";
 import { InstructionURLS } from "../config/urls";
-import { formatError } from "../utils/format-error";
 
 function createPlugin(urls: InstructionURLS): {
   plugin: Plugin;
@@ -52,6 +51,7 @@ function createPlugin(urls: InstructionURLS): {
             )}`
           );
         }
+
         if (isSuccessful && (process.stdout.isTTY || isFirstCompile)) {
           logger.log();
           logger.log(`You can now view ${chalk.bold(appName)} in the browser.`);
@@ -77,15 +77,6 @@ function createPlugin(urls: InstructionURLS): {
               `${chalk.cyan(`${useYarn ? "yarn" : "npm run"} build`)}.`
           );
           logger.log();
-        }
-
-        // If errors exist, only show errors.
-        if (result.errors.length) {
-          logger.log(chalk.red("Failed to compile.\n"));
-          // eslint-disable-next-line @typescript-eslint/no-misused-promises
-          result.errors.forEach(async (m) => {
-            logger.log(await formatError(m));
-          });
         }
 
         if (isFirstCompile) {

--- a/packages/esbuild-scripts/src/plugins/incremental-reporter.ts
+++ b/packages/esbuild-scripts/src/plugins/incremental-reporter.ts
@@ -1,0 +1,42 @@
+import { Plugin } from "esbuild";
+import chalk from "chalk";
+import * as logger from "../utils/logger";
+import { formatError } from "../utils/format-error";
+
+function createPlugin(): Plugin {
+  const plugin: Plugin = {
+    name: "incremental-errors",
+    setup(build) {
+      build.onEnd(async (result) => {
+        if (result.errors.length) {
+          logger.log(chalk.red("Failed to compile.\n"));
+        } else {
+          if (result.warnings.length) {
+            logger.log(chalk.red("Compiled with warnings.\n"));
+          }
+        }
+
+        // If errors exist, only show errors.
+        if (result.errors.length) {
+          await Promise.all(
+            result.errors.map(async (m) => {
+              logger.log(await formatError(m));
+            })
+          );
+        }
+
+        if (result.warnings.length) {
+          await Promise.all(
+            result.warnings.map(async (m) => {
+              logger.log(await formatError(m));
+            })
+          );
+        }
+      });
+    },
+  };
+
+  return plugin;
+}
+
+export default createPlugin;

--- a/packages/esbuild-scripts/src/runtime/index.ts
+++ b/packages/esbuild-scripts/src/runtime/index.ts
@@ -1,5 +1,4 @@
 import ErrorOverlay from "react-error-overlay";
-import { format } from "url";
 import stripAnsi from "strip-ansi";
 
 const isFirstCompilation: Record<string, boolean> = {};
@@ -34,16 +33,9 @@ ErrorOverlay.startReportingRuntimeErrors({
   filename: "/index.js",
 });
 
-const connection = new WebSocket(
-  format({
-    protocol: window.location.protocol === "https:" ? "wss" : "ws",
-    hostname: window.location.hostname,
-    port: window.location.port,
-    // Hardcoded in WebpackDevServer
-    pathname: "/_ws",
-    slashes: true,
-  })
-);
+const url = new URL("/_ws", window.location.href);
+url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+const connection = new WebSocket(url.toString());
 
 // Unlike WebpackDevServer client, we won't try to reconnect
 // to avoid spamming the console. Disconnect usually happens


### PR DESCRIPTION
Fix #13 where `url` cannot be resolved with esbuild for the runtime library injected into apps for error reporting. 