### PR TITLE
Add `await` to `minimize.minify` in build script

### DIFF
--- a/packages/esbuild-scripts/src/build/index.ts
+++ b/packages/esbuild-scripts/src/build/index.ts
@@ -42,7 +42,7 @@ void (async () => {
   const html = await createIndex(env.raw, false);
   await fs.writeFile(
     path.join(paths.appBuild, "index.html"),
-    minimize.minify(html, {
+    await minimize.minify(html, {
       html5: true,
       collapseBooleanAttributes: true,
       collapseWhitespace: true,


### PR DESCRIPTION
Love this package! Added it to existing React 18.2.0 project. Got strange error (below) running build and found that `minimize.minify` (now?) returns a `Promise`.
Adding an `await` here fixes it for me.
Node version v18.3.0
```
yarn run v1.22.19
$ react-scripts build
[esbuild-scripts] Creating an optimized production build...
/Users/tom/react/my-app/node_modules/@lukesheard/esbuild-scripts/build/index.js:30
    throw err;
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Promise
    at writeFile (node:fs:2159:5)
    at go$writeFile (/Users/tom/react/my-app/node_modules/graceful-fs/graceful-fs.js:138:14)
    at Object.writeFile (/Users/tom/react/my-app/node_modules/graceful-fs/graceful-fs.js:135:12)
    at /Users/tom/react/my-app/node_modules/universalify/index.js:8:12
    at new Promise (<anonymous>)
    at Object.writeFile (/Users/tom/react/my-app/node_modules/universalify/index.js:7:14)
    at /Users/tom/react/my-app/node_modules/@lukesheard/esbuild-scripts/build/build/index.js:62:30 {
  code: 'ERR_INVALID_ARG_TYPE'
}
```